### PR TITLE
Use the latest LibDBIcon API to show/hide minimap icons

### DIFF
--- a/Bazooka.lua
+++ b/Bazooka.lua
@@ -2373,8 +2373,10 @@ function Bazooka:disableDBIcon()
     return
   end
   local DBIcon = LibStub:GetLibrary("LibDBIcon-1.0", true)
-  if DBIcon and DBIcon.DisableLibrary then
-    DBIcon:DisableLibrary()
+  if DBIcon and DBIcon.Hide then
+    for k,_ in pairs(DBIcon.objects) do
+      DBIcon:Hide(k)
+    end
     self.isDBIconDisabled = true
   end
 end
@@ -2384,8 +2386,10 @@ function Bazooka:enableDBIcon()
     return
   end
   local DBIcon = LibStub:GetLibrary("LibDBIcon-1.0", true)
-  if DBIcon and DBIcon.EnableLibrary then
-    DBIcon:EnableLibrary()
+  if DBIcon and DBIcon.Show then
+    for k,_ in pairs(DBIcon.objects) do
+      DBIcon:Show(k)
+    end
     self.isDBIconDisabled = nil
   end
 end
@@ -2764,4 +2768,3 @@ local bft = bottomFrame:CreateTexture()
 bft:SetAllPoints()
 bft:SetTexture(.8, 0.4, 0.2, 0.5)
 --]]
-


### PR DESCRIPTION
Bazooka has been using an old API function for LibDBIcons to show/hide minimap icons. Because most addons are using the latest LibDBIcon-1.0 with a different API, this option in Bazooka generally doesn't work.

This PR fixes this. It updates it to use the latest API functions for `Show()` and `Hide()`. It iterates through the registered Icons and shows/hides each one.